### PR TITLE
[DEV-3698] Changes for multiple web hooks

### DIFF
--- a/causely_notification/server.py
+++ b/causely_notification/server.py
@@ -121,20 +121,29 @@ if __name__ == '__main__':
         # Extract the webhook name, type, url, and token
         webhook_name = webhook.get("name")  # REQUIRED
         webhook_type = webhook.get("hook_type")  # REQUIRED
-        webhook_url = webhook.get("url")  # REQUIRED
-        webhook_token = webhook.get("token")  # OPTIONAL
+        # Normalize the webhook name for environment variable lookup (uppercase and spaces to underscores)
+        normalized_name = webhook_name.upper().replace(" ", "_")
 
+        # Get the url and token and env vars.  In kubernetes this should be a
+        # secret.  In docker, create env vars
+        url_env_var = f"URL_{normalized_name}"
+        token_env_var = f"TOKEN_{normalized_name}"
+        url = os.getenv(url_env_var)
+        token = os.getenv(token_env_var)
+
+        if not url:
+            raise ValueError(f"Missing environment variable '{
+            url_env_var
+            }' for webhook '{webhook_name}'")
         if not webhook_name:
             raise ValueError("Webhook name is required in the configuration.")
         if not webhook_type:
             raise ValueError("Webhook type is required in the configuration.")
-        if not webhook_url:
-            raise ValueError("Webhook url is required in the configuration.")
 
         # Store the webhook URL and token in the lookup map
         webhook_lookup_map[webhook_name] = {
-            'url': webhook_url,
-            'token': webhook_token,
+            'url': url,
+            'token': token,
             'hook_type': webhook_type,
         }
 

--- a/causely_notification/server.py
+++ b/causely_notification/server.py
@@ -120,9 +120,13 @@ if __name__ == '__main__':
     for webhook in webhooks:
         # Extract the webhook name, type, url, and token
         webhook_name = webhook.get("name")  # REQUIRED
-        webhook_type = webhook.get("hook_type")  # REQUIRED
+        if not webhook_name:
+            raise ValueError("Webhook name is required in the configuration.")
         # Normalize the webhook name for environment variable lookup (uppercase and spaces to underscores)
         normalized_name = webhook_name.upper().replace(" ", "_")
+        webhook_type = webhook.get("hook_type")  # REQUIRED
+        if not webhook_type:
+            raise ValueError("Webhook type is required in the configuration.")
 
         # Get the url and token and env vars.  In kubernetes this should be a
         # secret.  In docker, create env vars
@@ -135,10 +139,6 @@ if __name__ == '__main__':
             raise ValueError(f"Missing environment variable '{
             url_env_var
             }' for webhook '{webhook_name}'")
-        if not webhook_name:
-            raise ValueError("Webhook name is required in the configuration.")
-        if not webhook_type:
-            raise ValueError("Webhook type is required in the configuration.")
 
         # Store the webhook URL and token in the lookup map
         webhook_lookup_map[webhook_name] = {


### PR DESCRIPTION
The existing logic related to multiple web hooks seemed to be routing based on the path that the executor posted to, which did not give flexibility to have multiple web hooks of different types.  The logic was changed to route to a main URL /webhooks and then from there read the causely bot web hook configuration and iterate over web hooks that should receive a certain notification.
Also, the logic was not using the tokens to take these from the causelybot config instead of env vars.

More testing needed.