### PR TITLE
[DEV-3754] Add logic to handle updates

### DIFF
--- a/causely_notification/jira.py
+++ b/causely_notification/jira.py
@@ -22,6 +22,7 @@ import sys
 import requests
 
 from .date import parse_iso_date
+from .utils import check_problem_detected
 
 
 def create_jira_description(payload):
@@ -123,7 +124,7 @@ def forward_to_jira(payload, jira_api_url, jira_auth_token):
     print(payload, file=sys.stderr)
     print(payload.get("type"), file=sys.stderr)
 
-    type_ = "Root Cause Identified" if payload.get("type") == "ProblemDetected" else "Root Cause Cleared"
+    type_ = "Root Cause Identified" if check_problem_detected(payload) else "Root Cause Cleared"
     jira_data = create_jira_payload(payload, type_)
 
     headers = {

--- a/causely_notification/opsgenie.py
+++ b/causely_notification/opsgenie.py
@@ -22,6 +22,7 @@ import sys
 import requests
 
 from .date import parse_iso_date
+from .utils import check_problem_detected
 
 
 def create_opsgenie_description(payload):
@@ -97,7 +98,7 @@ def forward_to_opsgenie(payload, opsgenie_api_url, opsgenie_api_key):
     print(payload, file=sys.stderr)
     print(payload.get("type"), file=sys.stderr)
 
-    type_ = "Root Cause Identified" if payload.get("type") == "ProblemDetected" else "Root Cause Cleared"
+    type_ = "Root Cause Identified" if check_problem_detected(payload) else "Root Cause Cleared"
     opsgenie_data = create_opsgenie_payload(payload, type_)
 
     headers = {

--- a/causely_notification/server.py
+++ b/causely_notification/server.py
@@ -24,6 +24,8 @@ from flask import Flask
 from flask import jsonify
 from flask import request
 
+from typing import Dict, Any
+
 from causely_notification.filter import WebhookFilterStore
 from causely_notification.jira import forward_to_jira
 from causely_notification.slack import forward_to_slack
@@ -44,7 +46,6 @@ def get_config():
 
 EXPECTED_TOKEN = os.getenv("AUTH_TOKEN")
 
-
 @app.route('/webhook', methods=['POST'])
 def webhook_routing():
     # Check for Bearer token in Authorization header
@@ -53,6 +54,24 @@ def webhook_routing():
         payload = request.json
         # Check if the payload passes the filter
         matching_webhooks = filter_store.filter_payload(payload)
+        print("Checking matching webhooks")
+
+        notifType = payload.get("type", "ProblemDetected")
+        # Specialized handling for problem updated, only send the notification
+        # when it wasn't sent before, or it was sent before but the severity reduced
+        if notifType == "ProblemUpdated":
+            # put the payload old severity into the payload and check which webhooks
+            # would have previously matched
+            tempPayload = request.json
+            oldSeverity = tempPayload.get("old_severity", "")
+            if oldSeverity != "":
+                tempPayload["severity"] = oldSeverity
+                old_matches = filter_store.filter_payload(tempPayload)
+                # Check if it matched before but didn't know - send an update
+                # Check if it didn't match before but does not - send an update
+                # Otherwise, no need to send an update - so get the webhooks that aren't in both sets
+                new_matches = list(set(old_matches) ^ set(matching_webhooks))
+                matching_webhooks = new_matches
         # If there are no matching webhooks, return 200 OK
         if not matching_webhooks:
             return jsonify({"message": "No matching webhooks found"}), 200
@@ -78,6 +97,7 @@ def webhook_routing():
                     failed_forwards.append(f"Unknown hook type: {hook_type}")
                     continue
 
+            print(response)
             if response.status_code in [200, 202]:
                 successful_forwards.append(name)
             else:
@@ -103,19 +123,14 @@ def webhook_routing():
     else:
         return jsonify({"message": "Unauthorized"}), 401
 
-
-if __name__ == '__main__':
-    # Step 1: Read the configuration file
-    config = get_config()
-    webhooks = config.get("webhooks", [])
-    if not webhooks:
-        raise ValueError("No webhooks found in the config.")
+def populate_webhooks(webhooks):
 
     # Step 2: Initialize the webhook filter store
     filter_store = WebhookFilterStore()
 
     # Step 3: Map of webhook names to their (url, token) from environment variables
     webhook_lookup_map = {}
+    print([w["name"] for w in webhooks])
 
     for webhook in webhooks:
         # Extract the webhook name, type, url, and token
@@ -154,6 +169,14 @@ if __name__ == '__main__':
 
         # Add the webhook filters to the filter store
         filter_store.add_webhook_filters(webhook_name, filter_values, enabled)
+    return filter_store, webhook_lookup_map
 
+if __name__ == '__main__':
+    # Step 1: Read the configuration file
+    config = get_config()
+    webhooks = config.get("webhooks", [])
+    if not webhooks:
+        raise ValueError("No webhooks found in the config.")
+    filter_store, webhook_lookup_map = populate_webhooks(webhooks)
     # Start the application
     app.run(host='0.0.0.0', port=5000)

--- a/causely_notification/server_test.py
+++ b/causely_notification/server_test.py
@@ -1,0 +1,254 @@
+# server_test.py
+from unittest.mock import patch, Mock
+
+import yaml
+import os
+import textwrap
+os.environ["URL_SLACK-MALFUNCTION-SLO"] = "http://test_slack"
+os.environ["URL_SLACK-SEVERITY"] = "http://test_slack"
+os.environ["AUTH_TOKEN"] = "test-token"
+
+from causely_notification.server import app
+from causely_notification.server import populate_webhooks
+from causely_notification import server
+
+test_payload = {
+    "link": "https://portal.staging.causely.app/rootCauses/d76f027d-e697-46ed-8a2c-f16356a97ceb",
+    "name": "Malfunction",
+    "type": "ProblemDetected",
+    "entity": {
+        "id": "ac462ed5-87cb-5a1a-9586-b2951b52adda",
+        "link": "https://portal.staging.causely.app/observe/topology/ac462ed5-87cb-5a1a-9586-b2951b52adda",
+        "name": "/webhook/teams",
+        "type": "HTTPPath"
+    },
+    "labels": {
+        "causely.ai/service-id": "fdea69a6-7ae3-504c-a5f9-cd450d135672",
+        "causely.ai/service-name": "causelybot"
+    },
+    "objectId": "d76f027d-e697-46ed-8a2c-f16356a97ceb",
+    "severity": "High",
+    "timestamp": "2025-08-07T18:51:54.164185287Z",
+    "description": {
+        "details": "A higher error rate can stem from multiple factors...",
+        "summary": "The HTTP path is experiencing a high rate of errors...",
+        "remediationOptions": [
+            {"title": "Check Logs", "description": "Inspect the application logs..."}
+        ]
+    }
+}
+
+test_payload_update = {
+    "link": "https://portal.staging.causely.app/rootCauses/d76f027d-e697-46ed-8a2c-f16356a97ceb",
+    "name": "Malfunction",
+    "type": "ProblemUpdated",
+    "entity": {
+        "id": "ac462ed5-87cb-5a1a-9586-b2951b52adda",
+        "link": "https://portal.staging.causely.app/observe/topology/ac462ed5-87cb-5a1a-9586-b2951b52adda",
+        "name": "/webhook/teams",
+        "type": "HTTPPath"
+    },
+    "labels": {
+        "causely.ai/service-id": "fdea69a6-7ae3-504c-a5f9-cd450d135672",
+        "causely.ai/service-name": "causelybot"
+    },
+    "objectId": "d76f027d-e697-46ed-8a2c-f16356a97ceb",
+    "severity": "High",
+    "old_severity": "Low",
+    "timestamp": "2025-08-07T18:51:54.164185287Z",
+    "description": {
+        "details": "A higher error rate can stem from multiple factors...",
+        "summary": "The HTTP path is experiencing a high rate of errors...",
+        "remediationOptions": [
+            {"title": "Check Logs", "description": "Inspect the application logs..."}
+        ]
+    }
+}
+
+test_payload_update_lower = {
+    "link": "https://portal.staging.causely.app/rootCauses/d76f027d-e697-46ed-8a2c-f16356a97ceb",
+    "name": "Malfunction",
+    "type": "ProblemUpdated",
+    "entity": {
+        "id": "ac462ed5-87cb-5a1a-9586-b2951b52adda",
+        "link": "https://portal.staging.causely.app/observe/topology/ac462ed5-87cb-5a1a-9586-b2951b52adda",
+        "name": "/webhook/teams",
+        "type": "HTTPPath"
+    },
+    "labels": {
+        "causely.ai/service-id": "fdea69a6-7ae3-504c-a5f9-cd450d135672",
+        "causely.ai/service-name": "causelybot"
+    },
+    "objectId": "d76f027d-e697-46ed-8a2c-f16356a97ceb",
+    "severity": "Low",
+    "old_severity": "High",
+    "timestamp": "2025-08-07T18:51:54.164185287Z",
+    "description": {
+        "details": "A higher error rate can stem from multiple factors...",
+        "summary": "The HTTP path is experiencing a high rate of errors...",
+        "remediationOptions": [
+            {"title": "Check Logs", "description": "Inspect the application logs..."}
+        ]
+    }
+}
+
+test_payload_update_same = {
+    "link": "https://portal.staging.causely.app/rootCauses/d76f027d-e697-46ed-8a2c-f16356a97ceb",
+    "name": "Malfunction",
+    "type": "ProblemUpdated",
+    "entity": {
+        "id": "ac462ed5-87cb-5a1a-9586-b2951b52adda",
+        "link": "https://portal.staging.causely.app/observe/topology/ac462ed5-87cb-5a1a-9586-b2951b52adda",
+        "name": "/webhook/teams",
+        "type": "HTTPPath"
+    },
+    "labels": {
+        "causely.ai/service-id": "fdea69a6-7ae3-504c-a5f9-cd450d135672",
+        "causely.ai/service-name": "causelybot"
+    },
+    "objectId": "d76f027d-e697-46ed-8a2c-f16356a97ceb",
+    "severity": "High",
+    "old_severity": "High",
+    "timestamp": "2025-08-07T18:51:54.164185287Z",
+    "description": {
+        "details": "A higher error rate can stem from multiple factors...",
+        "summary": "The HTTP path is experiencing a high rate of errors...",
+        "remediationOptions": [
+            {"title": "Check Logs", "description": "Inspect the application logs..."}
+        ]
+    }
+}
+
+yaml_text = textwrap.dedent("""
+webhooks:
+  - name: "slack-severity"
+    url: "https://hooks.slack.com/services/T00000000/B00000001/XXXXXXXXXXXXXXXXXXXXXXXX"
+    token: ""
+    hook_type: slack
+    filters:
+      enabled: true
+      values:
+        - field: "severity"
+          operator: "in"
+          value: ["High", "Critical"]
+  - name: "slack-malfunction-slo"
+    url: "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+    token: ""
+    hook_type: slack
+    filters:
+      enabled: true
+      values:
+        - field: "name"
+          operator: "equals"
+          value: "Malfunction"
+        - field: "impactsSLO"
+          operator: "equals"
+          value: true
+""")
+
+@patch("requests.post")
+# Mock post to webhooks with 1 matching webhook
+def test_webhook_posts_expected_payload(mock_post):
+    # 2) minimal stub for SECOND call (only to avoid network / errors)
+    second_resp = Mock(status_code=202)
+    second_resp.json.return_value = {"ok": True}
+    second_resp.raise_for_status.return_value = None
+
+    mock_post.side_effect = [second_resp]
+
+    webhook_data = yaml.safe_load(yaml_text)
+    webhooks = webhook_data.get("webhooks")
+
+    filter_store, webhook_lookup_map = populate_webhooks(webhooks)
+    server.filter_store = filter_store
+    server.webhook_lookup_map = webhook_lookup_map
+    client = app.test_client()
+    resp = client.post("/webhook", json=test_payload, headers={"Authorization": "Bearer test-token"})  # this sets flask.request for you
+    assert resp.status_code == 200
+
+    # Assertions
+    assert mock_post.call_count == 1
+
+    # Second call URL
+    second_url = "http://test_slack"
+    url2 = mock_post.call_args_list[0].args[0]
+    assert url2 == second_url
+
+# Mock post to webhooks that is an update - severity going up
+@patch("requests.post")
+def test_webhook_posts_expected_payload2(mock_post):
+    # 2) minimal stub for SECOND call (only to avoid network / errors)
+    second_resp = Mock(status_code=202)
+    second_resp.json.return_value = {"ok": True}
+    second_resp.raise_for_status.return_value = None
+
+    mock_post.side_effect = [second_resp]
+
+    webhook_data = yaml.safe_load(yaml_text)
+    webhooks = webhook_data.get("webhooks")
+
+    filter_store, webhook_lookup_map = populate_webhooks(webhooks)
+    server.filter_store = filter_store
+    server.webhook_lookup_map = webhook_lookup_map
+    client = app.test_client()
+    resp = client.post("/webhook", json=test_payload_update, headers={"Authorization": "Bearer test-token"})  # this sets flask.request for you
+    assert resp.status_code == 200
+
+    # Assertions
+    assert mock_post.call_count == 1
+
+    # Second call URL
+    second_url = "http://test_slack"
+    url2 = mock_post.call_args_list[0].args[0]
+    assert url2 == second_url
+
+# Mock post to webhooks that is an update - severity going down
+@patch("requests.post")
+def test_webhook_posts_expected_payload3(mock_post):
+    # 2) minimal stub for SECOND call (only to avoid network / errors)
+    second_resp = Mock(status_code=202)
+    second_resp.json.return_value = {"ok": True}
+    second_resp.raise_for_status.return_value = None
+
+    mock_post.side_effect = [second_resp]
+
+    webhook_data = yaml.safe_load(yaml_text)
+    webhooks = webhook_data.get("webhooks")
+
+    filter_store, webhook_lookup_map = populate_webhooks(webhooks)
+    server.filter_store = filter_store
+    server.webhook_lookup_map = webhook_lookup_map
+    client = app.test_client()
+    resp = client.post("/webhook", json=test_payload_update_lower, headers={"Authorization": "Bearer test-token"})  # this sets flask.request for you
+    assert resp.status_code == 200
+
+    # Assertions
+    assert mock_post.call_count == 1
+
+    # Second call URL
+    second_url = "http://test_slack"
+    url2 = mock_post.call_args_list[0].args[0]
+    assert url2 == second_url
+
+# Mock post to webhooks that is an update - severity same - no post to slack
+@patch("requests.post")
+def test_webhook_posts_expected_payload4(mock_post):
+    # 2) minimal stub for SECOND call (only to avoid network / errors)
+    second_resp = Mock(status_code=202)
+    second_resp.json.return_value = {"ok": True}
+    second_resp.raise_for_status.return_value = None
+
+    mock_post.side_effect = [second_resp]
+
+    webhook_data = yaml.safe_load(yaml_text)
+    webhooks = webhook_data.get("webhooks")
+
+    filter_store, webhook_lookup_map = populate_webhooks(webhooks)
+    server.filter_store = filter_store
+    server.webhook_lookup_map = webhook_lookup_map
+    client = app.test_client()
+    resp = client.post("/webhook", json=test_payload_update_same, headers={"Authorization": "Bearer test-token"})  # this sets flask.request for you
+    assert resp.status_code == 200
+
+    # Assertions
+    assert mock_post.call_count == 0

--- a/causely_notification/slack.py
+++ b/causely_notification/slack.py
@@ -22,6 +22,7 @@ import sys
 import requests
 
 from .date import parse_iso_date
+from .utils import check_problem_detected
 
 
 def create_slack_description_block(payload):
@@ -263,7 +264,7 @@ def forward_to_slack(payload, slack_webhook_url, slack_webhook_token):
     print(payload, file=sys.stderr)
     print(payload.get("type"), file=sys.stderr)
 
-    if payload.get("type") == "ProblemDetected":
+    if check_problem_detected(payload):
         slack_data = {
             "username": "Causely",
             "icon_emoji": ":causely:",

--- a/causely_notification/teams.py
+++ b/causely_notification/teams.py
@@ -22,6 +22,7 @@ import sys
 import requests
 
 from .date import parse_iso_date
+from .utils import check_problem_detected
 
 
 def create_teams_description_block(payload):
@@ -262,7 +263,7 @@ def forward_to_teams(payload, teams_webhook_url):
     print(f"Processing Teams webhook for payload type: {payload.get('type')}", file=sys.stderr)
     print(f"Teams webhook URL: {teams_webhook_url}", file=sys.stderr)
 
-    if payload.get("type") == "ProblemDetected":
+    if check_problem_detected(payload):
         teams_data = create_teams_detected_payload(payload)
     else:
         teams_data = create_teams_cleared_payload(payload)

--- a/causely_notification/utils.py
+++ b/causely_notification/utils.py
@@ -1,0 +1,21 @@
+
+# Copyright 2025 Causely, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+def check_problem_detected(payload):
+    if payload.get("type") == "ProblemDetected" or payload.get("type") == "ProblemUpdated":
+        return True
+    return False


### PR DESCRIPTION
Added logic to handle a new type ProblemUpdated.  This should be treated in the same way in most cases as a problem detected.  The logic checks the old and new severity of the problem updated.  If the old severity and new severity are the same, the problem update is ignored.  In other cases, the problem updated is sent.  
There are 2 cases, in one case the severity previously did not match and now matches, this is sent.  In another case, the severity previously matched and now does not match.  This case is sent so that the user knows that the severity is decreased.

Also added a unit test the mocks the posts.