### PR TITLE
handle empty token value

### DIFF
--- a/helm/causelybot/templates/bot_deployment.yaml
+++ b/helm/causelybot/templates/bot_deployment.yaml
@@ -53,11 +53,13 @@ spec:
             secretKeyRef:
               name: causelybot-secret-{{ .name | lower | replace " " "-" }}
               key: webhook-url
+        {{- if .token }}
         - name: TOKEN_{{ .name | upper | replace " " "_" }}
           valueFrom:
             secretKeyRef:
               name: causelybot-secret-{{ .name | lower | replace " " "-" }}
               key: token
+        {{- end }}
         {{- end }}
         
         resources:

--- a/helm/causelybot/templates/bot_secret.yaml
+++ b/helm/causelybot/templates/bot_secret.yaml
@@ -36,5 +36,7 @@ metadata:
 type: Opaque
 data:
   webhook-url: {{ .url | default "" | b64enc }}
+  {{- if .token }}
   token: {{ .token | default "" | b64enc }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
if some sets an empty token value, it is missing from the secret and results in
```
$ kubectl get pods
NAME                                      READY   STATUS                       RESTARTS          AGE
causelybot-6974ff4cc-lf7cm                0/1     CreateContainerConfigError   0                 3s
```
because the token value will not exist in the secret